### PR TITLE
always return list in RTFastaFile.get_base, presumably fixes #35

### DIFF
--- a/reditools/fasta_file.py
+++ b/reditools/fasta_file.py
@@ -50,7 +50,7 @@ class RTFastaFile(PysamFastaFile):
             self._update_contig_cache(contig)
         try:
             if len(position) == 1:
-                return self._contig_cache[position[0]]
+                return [self._contig_cache[position[0]]]
             return [self._contig_cache[idx] for idx in position]
         except IndexError as exc:
             raise IndexError(


### PR DESCRIPTION
When providing a single position `get_base(self, contig, *position)` from `RTFastaFile` returns a single character as string, which later causes `[ERROR] (<class 'AttributeError'>) 'str' object has no attribute 'pop'` error (https://github.com/BioinfoUNIBA/REDItools3/issues/35). 

This commit ensure list object is always returned. If this affects some other functionality and a more complicated fix is required, feel free to ignore the PR. However, it did fix the error in my case.