### PR TITLE
Right clip fix

### DIFF
--- a/reditools/compiled_reads.py
+++ b/reditools/compiled_reads.py
@@ -98,10 +98,10 @@ class CompiledReads(object):
         return not self._nucleotides
 
     def _get_ref_from_read(self, read):
-        return (_[2].upper() for _ in read.get_aligned_pairs(
+        return [_[2].upper() for _ in read.get_aligned_pairs(
             with_seq=True,
             matches_only=True,
-        ))
+        )]
 
     def _get_ref_from_fasta(self, read):
         pairs = read.get_aligned_pairs(matches_only=True)
@@ -118,13 +118,13 @@ class CompiledReads(object):
         ref_seq = self._ref_seq(read)
         while pairs and pairs[0][0] < self._qc['min_base_position']:
             pairs.pop(0)
-            next(ref_seq)
+            ref_seq.pop(0)
         if not pairs:
             return
 
         while pairs and self._qc_base_position(read, pairs[0][0]):
             offset, ref_pos = pairs.pop(0)
-            ref_base = next(ref_seq)
+            ref_base = ref_seq.pop(0)
             if ref_base != 'N' != seq[offset]:
                 if qualities[offset] >= self._qc['min_base_quality']:
                     yield (ref_pos, seq[offset], qualities[offset], ref_base)

--- a/reditools/fasta_file.py
+++ b/reditools/fasta_file.py
@@ -49,7 +49,7 @@ class RTFastaFile(PysamFastaFile):
         if contig != self._contig_name:
             self._update_contig_cache(contig)
         try:
-            return (self._contig_cache[idx] for idx in position)
+            return [self._contig_cache[idx] for idx in position]
         except IndexError as exc:
             raise IndexError(
                 f'Base position {position} is outside the bounds of ' +


### PR DESCRIPTION
Programmatic defaults for right clipping are `float('inf')`. This changes that to zero.