### PR TITLE
Strand filter

### DIFF
--- a/reditools/reditools.py
+++ b/reditools/reditools.py
@@ -187,8 +187,7 @@ class REDItools:
             strand = bases.calculate_strand(
                 threshold=self.strand_confidence_threshold,
             )
-            if self._use_strand_correction and strand != '*':
-                bases.filter_by_strand(strand)
-                if strand == '-':
-                    bases.complement()
+            bases.filter_by_strand(strand)
+            if self._use_strand_correction and strand == '-':
+                bases.complement()
         return RTResult(bases, strand)

--- a/reditools/tools/analyze/parse_args.py
+++ b/reditools/tools/analyze/parse_args.py
@@ -285,7 +285,8 @@ def build_argument_parser() -> argparse.ArgumentParser:  # noqa: WPS213, WPS210
         type=int,
         default=reditools.UNSTRANDED_MODE,
         help=(
-            f'Strand can be {reditools.UNSTRANDED_MODE} (unstranded), '
+            f'Infer RNA strand and filter reads not of the same strand. '
+            f'This option may be {reditools.UNSTRANDED_MODE} (unstranded), '
             f'{reditools.FORWARD_STRAND_MODE} (read1 is original RNA), or '
             f'{reditools.REVERSE_STRAND_MODE} (read2 is original RNA). '
             'From RSeQC infer_experiment.py, 1++,1--,2+-,2-+ should be run '
@@ -314,9 +315,10 @@ def build_argument_parser() -> argparse.ArgumentParser:  # noqa: WPS213, WPS210
         '--strand-correction',
         default=False,
         help=(
-            'Once the strand has been inferred, only bases according to this '
-            'strand will be reported. This option is only applicable if '
-            '-s/--strand is not zero.'
+            'Report the base complements for the Reference, AllSubs, and '
+            'BaseCount columns in the output if the detected edit is on '
+            'the minus strand. '
+            'This option is only applicable if -s/--strand is not zero.'
         ),
         action='store_true',
     )

--- a/test/reditools.py
+++ b/test/reditools.py
@@ -27,35 +27,40 @@ class TestREDItools(unittest.TestCase):
         self.rtam = AlignmentManager()
         self.rtam.add_file(self.bam_file)
 
+        self.cp = CompiledPosition(ref='A', position=1, contig='chr1')
+        self.cp.add_base(30, '-', 'A')
+        self.cp.add_base(30, '-', 'A')
+        self.cp.add_base(30, '-', 'A')
+        self.cp.add_base(30, '-', 'T')
+        self.cp.add_base(30, '+', 'G')
+        self.cp.add_base(30, '+', 'G')
+
     def tearDown(self):
         os.remove(self.bam_file)
         os.remove(self.fa_file)
 
     def test_process_bases(self):
-        cp = CompiledPosition(ref='A', position=1, contig='chr1')
-        cp.add_base(30, '-', 'A')
-        cp.add_base(30, '-', 'A')
-        cp.add_base(30, '-', 'A')
-        cp.add_base(30, '+', 'G')
-        cp.add_base(30, '+', 'G')
-
-        rtresult = self.rtools._process_bases(cp)
+        rtresult = self.rtools._process_bases(self.cp)
         self.assertEqual(rtresult.reference, 'A')
         self.assertEqual(rtresult.strand, '*')
-        self.assertEqual(rtresult.variants, ['AG'])
+        self.assertEqual(rtresult.variants, ['AG', 'AT'])
 
+    def test_strand_filter(self):
         self.rtools.strand = reditools.FORWARD_STRAND_MODE
         self.rtools.strand_confidence_threshold = 0.5
-        rtresult = self.rtools._process_bases(cp)
+        rtresult = self.rtools._process_bases(self.cp)
         self.assertEqual(rtresult.strand, '-')
         self.assertEqual(rtresult.reference, 'A')
-        self.assertEqual(rtresult.variants, ['AG'])
+        self.assertEqual(rtresult.variants, ['AT'])
 
+    def test_strand_correction(self):
+        self.rtools.strand = reditools.FORWARD_STRAND_MODE
+        self.rtools.strand_confidence_threshold = 0.5
         self.rtools.use_strand_correction()
-        rtresult = self.rtools._process_bases(cp)
+        rtresult = self.rtools._process_bases(self.cp)
         self.assertEqual(rtresult.strand, '-')
         self.assertEqual(rtresult.reference, 'T')
-        self.assertEqual(rtresult.variants, [])
+        self.assertEqual(rtresult.variants, ['TA'])
 
     def test_add_reference(self):
         rtresult = next(


### PR DESCRIPTION
Output filters by strand when using the `--strand` option instead of the `--strand-correction` option.